### PR TITLE
Queue 생성 및 기존 exchange와 binding 설정

### DIFF
--- a/src/main/java/com/nhnacademy/eggplantdelivery/config/RabbitmqConfig.java
+++ b/src/main/java/com/nhnacademy/eggplantdelivery/config/RabbitmqConfig.java
@@ -31,6 +31,7 @@ public class RabbitmqConfig {
     public static final String ROUTING_EGGPLANT = "routing.Eggplant";
     public static final String ROUTING_TRACKING_NO = "routing.TrackingNo";
     public static final String ROUTING_UPDATE_STATUS = "routing.UpdateStatus";
+    public static final String ROUTING_DELIVERY_ARRIVAL = "routing.DeliveryArrival"
     private String host;
     private int port;
     private String username;
@@ -121,13 +122,18 @@ public class RabbitmqConfig {
     }
 
     @Bean
+    Queue queueDeliveryArrival() {
+        return new Queue("queue.DeliveryArrival", false);
+    }
+
+    @Bean
     DirectExchange exchange() {
         return new DirectExchange("exchange.direct");
     }
 
     @Bean
     Binding bindEggplant(final Queue queueEggplant,
-                         final DirectExchange exchange) {
+        final DirectExchange exchange) {
 
         return BindingBuilder.bind(queueEggplant)
                              .to(exchange)
@@ -136,7 +142,7 @@ public class RabbitmqConfig {
 
     @Bean
     Binding bindTrackingNo(final Queue queueTrackingNo,
-                           final DirectExchange exchange) {
+        final DirectExchange exchange) {
 
         return BindingBuilder.bind(queueTrackingNo)
                              .to(exchange)
@@ -145,11 +151,20 @@ public class RabbitmqConfig {
 
     @Bean
     Binding bindCompletionStatus(final Queue queueUpdateStatus,
-                                 final DirectExchange exchange) {
+        final DirectExchange exchange) {
 
         return BindingBuilder.bind(queueUpdateStatus)
                              .to(exchange)
-                             .with(ROUTING_TRACKING_NO);
+                             .with(ROUTING_UPDATE_STATUS);
+    }
+
+    @Bean
+    Binding bindDeliveryArrival(final Queue queueDeliveryArrival,
+        final DirectExchange exchange) {
+
+        return BindingBuilder.bind(queueDeliveryArrival)
+            .to(exchange)
+            .with(ROUTING_DELIVERY_ARRIVAL);
     }
 
 }

--- a/src/main/java/com/nhnacademy/eggplantdelivery/config/RabbitmqConfig.java
+++ b/src/main/java/com/nhnacademy/eggplantdelivery/config/RabbitmqConfig.java
@@ -31,7 +31,7 @@ public class RabbitmqConfig {
     public static final String ROUTING_EGGPLANT = "routing.Eggplant";
     public static final String ROUTING_TRACKING_NO = "routing.TrackingNo";
     public static final String ROUTING_UPDATE_STATUS = "routing.UpdateStatus";
-    public static final String ROUTING_DELIVERY_ARRIVAL = "routing.DeliveryArrival"
+    public static final String ROUTING_DELIVERY_ARRIVAL = "routing.DeliveryArrival";
     private String host;
     private int port;
     private String username;


### PR DESCRIPTION
## 개요

- #32 
- 배송완료 상태로 변경 후 해당 쇼핑몰로 상태 전송 위한 Queue 생성 및 기존 exchange와 binding 설정

## 작업사항

- [x] Queue 생성
- [x] Routing key 생성
- [x] Binding 설정

> Co-Authored By @bunsung92 @JoisFe
> Advice By @Corock @EastHeat10  
